### PR TITLE
netserver: don't change permissions on /dev/null

### DIFF
--- a/src/netserver.c
+++ b/src/netserver.c
@@ -278,7 +278,8 @@ open_debug_file()
 
 #if !defined(WIN32)
 
-  chmod(FileName,0644);
+  if (!suppress_debug)
+    chmod(FileName,0644);
 
   /* redirect stdin to "/dev/null" */
   rd_null_fp = fopen(NETPERF_NULL,"r");


### PR DESCRIPTION
the (now default) suppress_debug=1 changes permissions on /dev/null to 0644. Don't do this.