### PR TITLE
src/nettest_bsd.c: Assign the return value of netperf_sendfile to len

### DIFF
--- a/src/nettest_bsd.c
+++ b/src/nettest_bsd.c
@@ -4665,7 +4665,7 @@ Size (bytes)\n\
 
       /* you can look at netlib.h for a description of the fields we
 	 are passing to sendfile(). 08/2000 */
-      if (netperf_sendfile(send_socket, send_ring) != send_size) {
+      if (len = netperf_sendfile(send_socket, send_ring) != send_size) {
 	/* the test was interrupted, must be the end of test. the
 	   send_tcp_stream code has some WIN32 ifdefs that we do not
 	   need here. */


### PR DESCRIPTION
len is declared but not assigned in sendfile_tcp_stream() so that running netperf -t TCP_SENDFILE in loops may get random and unexpected len, for example:
netperf: data send error: sendfile: No space left on device len was -1334480592 send_size was 10240

Add the missing assignment to fix the issue.

Reported-by: kernel test robot <lkp@intel.com>